### PR TITLE
Update TeslaFi Widget.js to use special characters in vehicle name

### DIFF
--- a/TeslaFi Widget.js
+++ b/TeslaFi Widget.js
@@ -565,7 +565,7 @@ function errorWidget(reason){
  
 async function loadItems() {
  
-	let url = "https://www.teslafi.com/feed.php?token="+APIkey+"&command=lastGood"
+	let url = "https://www.teslafi.com/feed.php?token="+APIkey+"&command=lastGood&encode=1"
 	let req = new Request(url)
 	let json = await req.loadJSON()
 	return json


### PR DESCRIPTION
From TeslaFi's API docs: If the vehicle name contains special characters &encode=1 may need to be added.